### PR TITLE
fix: fix ja3 calculate hanshake version mismatch

### DIFF
--- a/fp.go
+++ b/fp.go
@@ -63,6 +63,7 @@ func (obj ClientHello) UtlsExtensions() map[uint16]utls.TLSExtension {
 
 type TlsData struct {
 	connectionState    tls.ConnectionState
+	HandshakeVersion   uint16
 	Ciphers            []uint16
 	Curves             []uint16
 	Extensions         []uint16
@@ -77,7 +78,7 @@ type TlsData struct {
 }
 
 func (tlsData TlsData) Fp() (string, string) {
-	tlsVersion := fmt.Sprintf("%d", tlsData.connectionState.Version)
+	tlsVersion := fmt.Sprintf("%d", tlsData.HandshakeVersion)
 	ciphers := clearGreas(tlsData.Ciphers)
 	extensions := clearGreas(tlsData.Extensions)
 	curves := clearGreas(tlsData.Curves)
@@ -115,6 +116,7 @@ func (obj FpContextData) TlsData() (tlsData TlsData, err error) {
 		return tlsData, err
 	}
 	tlsData.connectionState = obj.connectionState
+	tlsData.HandshakeVersion = clientHello.HandshakeVersion
 	tlsData.Ciphers = clientHello.CipherSuites
 	tlsData.Curves = clientHello.Curves()
 	tlsData.Extensions = []uint16{}

--- a/fp.go
+++ b/fp.go
@@ -273,6 +273,10 @@ func decodeClientHello(clienthello []byte) (clientHelloInfo ClientHello, err err
 		var extension uint16
 		var extData cryptobyte.String
 		if extensionsData.ReadUint16(&extension) && extensionsData.ReadUint16LengthPrefixed(&extData) {
+			if extension == 21 {
+				// skip padding tls extension
+				continue
+			}
 			clientHelloInfo.Extensions = append(clientHelloInfo.Extensions, Extension{
 				Type: extension,
 				Data: extData,


### PR DESCRIPTION
As saleforce blog https://engineering.salesforce.com/tls-fingerprinting-with-ja3-and-ja3s-247362855967/

> The field order is as follows:
TLSVersion,Ciphers,Extensions,EllipticCurves,EllipticCurvePointFormats 